### PR TITLE
feat: add monitor pause & maintenance mode

### DIFF
--- a/src/app/api/pause/route.ts
+++ b/src/app/api/pause/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { pauseMonitor } from '@/lib/storage'
+import { z } from 'zod'
+
+const pauseSchema = z.object({
+  id: z.string().uuid(),
+  reason: z.string().optional(),
+  until: z.string().datetime().optional()
+})
+
+// POST /api/pause - Pause a monitor
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const validated = pauseSchema.parse(body)
+
+    const monitor = pauseMonitor(validated.id, validated.reason, validated.until)
+    if (!monitor) {
+      return NextResponse.json({ error: 'Monitor not found' }, { status: 404 })
+    }
+
+    return NextResponse.json(monitor)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({
+        error: error.issues.map(e => e.message).join(', ')
+      }, { status: 400 })
+    }
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+}

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { resumeMonitor } from '@/lib/storage'
+import { z } from 'zod'
+
+const resumeSchema = z.object({
+  id: z.string().uuid()
+})
+
+// POST /api/resume - Resume a paused monitor
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const validated = resumeSchema.parse(body)
+
+    const monitor = resumeMonitor(validated.id)
+    if (!monitor) {
+      return NextResponse.json({ error: 'Monitor not found' }, { status: 404 })
+    }
+
+    return NextResponse.json(monitor)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({
+        error: error.issues.map(e => e.message).join(', ')
+      }, { status: 400 })
+    }
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -13,6 +13,72 @@ function ensureDataDir() {
 
 let db: Database.Database | null = null
 
+// Migration definitions - add new migrations at the end with incrementing version
+interface Migration {
+  version: number
+  description: string
+  up: (db: Database.Database) => void
+}
+
+const migrations: Migration[] = [
+  {
+    version: 1,
+    description: 'Add pause functionality columns to monitors',
+    up: (database) => {
+      // Check if columns already exist (for databases created with new schema)
+      const columns = database.prepare(`PRAGMA table_info(monitors)`).all() as { name: string }[]
+      const columnNames = columns.map(c => c.name)
+
+      if (!columnNames.includes('paused')) {
+        database.exec(`ALTER TABLE monitors ADD COLUMN paused INTEGER NOT NULL DEFAULT 0`)
+      }
+      if (!columnNames.includes('paused_at')) {
+        database.exec(`ALTER TABLE monitors ADD COLUMN paused_at TEXT`)
+      }
+      if (!columnNames.includes('paused_until')) {
+        database.exec(`ALTER TABLE monitors ADD COLUMN paused_until TEXT`)
+      }
+      if (!columnNames.includes('pause_reason')) {
+        database.exec(`ALTER TABLE monitors ADD COLUMN pause_reason TEXT`)
+      }
+    }
+  }
+]
+
+function runMigrations(database: Database.Database) {
+  // Create migrations table if it doesn't exist
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version INTEGER PRIMARY KEY,
+      description TEXT NOT NULL,
+      applied_at TEXT NOT NULL
+    )
+  `)
+
+  // Get applied migrations
+  const applied = database.prepare(`SELECT version FROM schema_migrations`).all() as { version: number }[]
+  const appliedVersions = new Set(applied.map(m => m.version))
+
+  // Run pending migrations in order
+  const insertMigration = database.prepare(`
+    INSERT INTO schema_migrations (version, description, applied_at)
+    VALUES (?, ?, ?)
+  `)
+
+  for (const migration of migrations) {
+    if (!appliedVersions.has(migration.version)) {
+      console.log(`Running migration ${migration.version}: ${migration.description}`)
+
+      database.transaction(() => {
+        migration.up(database)
+        insertMigration.run(migration.version, migration.description, new Date().toISOString())
+      })()
+
+      console.log(`Migration ${migration.version} completed`)
+    }
+  }
+}
+
 // Graceful shutdown handling
 function setupShutdownHandlers() {
   const shutdown = () => {
@@ -43,7 +109,7 @@ export function getDb(): Database.Database {
   // Set up shutdown handlers on first connection
   setupShutdownHandlers()
 
-  // Create tables if they don't exist
+  // Create base tables if they don't exist (for new databases)
   db.exec(`
     CREATE TABLE IF NOT EXISTS monitors (
       id TEXT PRIMARY KEY,
@@ -73,6 +139,9 @@ export function getDb(): Database.Database {
     CREATE INDEX IF NOT EXISTS idx_pings_monitor_timestamp
     ON pings(monitor_id, timestamp DESC);
   `)
+
+  // Run migrations for existing databases
+  runMigrations(db)
 
   return db
 }


### PR DESCRIPTION
## Summary
- Add pause/paused_at/paused_until/pause_reason columns to monitors table
- Update Monitor interface to include pause fields and 'paused' status
- Add pauseMonitor(), resumeMonitor(), and checkAndResumeMonitors() functions
- Create /api/pause and /api/resume endpoints
- Add pause/resume buttons in monitor UI
- Add paused stat card in dashboard
- Display pause reason when monitor is paused
- Support auto-resume functionality with pausedUntil timestamp

Implements #2

🦾 Generated with [Claude Code](https://claude.ai/code)